### PR TITLE
Python 3 port

### DIFF
--- a/foaas.py
+++ b/foaas.py
@@ -5,7 +5,7 @@ from optparse import OptionParser
 
 __AUTHOR__ = 'Derek Payton <derek.payton@gmail.com>'
 __LICENSE__ = 'MIT'
-__VERSION__ = '0.0.1'
+__VERSION__ = '0.0.2'
 
 
 class FuckingResponse(object):
@@ -110,6 +110,6 @@ if __name__ == '__main__':
 
     fucking = getattr(fuck, action)(**options)
     if url_only:
-        print fucking.url
+        print(fucking.url)
     else:
-        print fucking.text
+        print(fucking.text)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ except ImportError:
 
 setup(
     name='foaas',
-    version='0.0.1',
+    version='0.0.2',
     description='Fuck Off As A Service',
     license='MIT',
     url='https://github.com/dmpayton/foaas-python',


### PR DESCRIPTION
Changed print to print(), now successfully imports into Python 3 (tried with Python 3.4.2).  No real testing beyond that.  Bumped version number in script and in setup file.

You should double-check that it behaves in py3, but otherwise it ought to be ready to go.  This is the easiest py3 port I've ever done.

The tests.py script probably needs expansion now that FOAAS has been resurrected and new end points are being added.  Also, when it looked like FOAAS was abondoned I went down my own path with [FOAD](https://github.com/adversary-org/foad), it's a different type of thing and is self-contained, but there are bits in foad.py you might like (if it wasn't Python I wouldn't have mentioned it).  It is a bit bigger, though and it's less constrained in output options (over 180 of them now, including some original ones and some Latin).  It's GPLv3, but I also dual-licensed it as [WTFNMFPLv1](https://github.com/adversary-org/wtfnmf) for situations like this.  OTOH, it's not the best code ever and it requires Python 3.2 and above, but fuck it, it works for me.  ;)

"Omnia quia sunt, futūtum sunt."
-- foad.py -f omnia
